### PR TITLE
feat: add a test case for the Playground request

### DIFF
--- a/src/Command/TestGuideCommand.php
+++ b/src/Command/TestGuideCommand.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\PDGBundle\Command;
 
 use ApiPlatform\PDGBundle\Services\ConfigurationHandler;
 use ApiPlatform\PDGBundle\Tests\TestBundle\Command\PhpUnitCommand;
+use ApiPlatform\PDGBundle\Tests\TestBundle\Guide\PlaygroundTestCase;
 use App\Kernel;
 use PHPUnit\Framework\TestSuite;
 use Symfony\Component\Console\Command\Command;
@@ -55,6 +56,7 @@ final class TestGuideCommand extends Command
         foreach ($testClasses as $testClass) {
             $suite->addTestSuite($testClass);
         }
+        $suite->addTestSuite(PlaygroundTestCase::class);
 
         PhpUnitCommand::setSuite($suite);
         $_ENV['KERNEL_CLASS'] = Kernel::class;

--- a/tests/Application/src/Kernel.php
+++ b/tests/Application/src/Kernel.php
@@ -31,12 +31,13 @@ use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\HttpFoundation\Request; // @phpstan-ignore-line
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 
 use function App\DependencyInjection\configure;
 use function App\Playground\request;
 
- // @phpstan-ignore-line
+// @phpstan-ignore-line
 
 class Kernel extends BaseKernel
 {
@@ -91,7 +92,7 @@ class Kernel extends BaseKernel
         }
     }
 
-    public function request(?Request $request = null): void
+    public function request(?Request $request = null): Response
     {
         if (null === $request && \function_exists('App\Playground\request')) {
             $request = request();
@@ -101,6 +102,8 @@ class Kernel extends BaseKernel
         $response = $this->handle($request);
         $response->send();
         $this->terminate($request, $response);
+
+        return $response;
     }
 
     public function getCacheDir(): string

--- a/tests/TestBundle/Guide/PlaygroundTestCase.php
+++ b/tests/TestBundle/Guide/PlaygroundTestCase.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\PDGBundle\Tests\TestBundle\Guide;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+
+use function App\Playground\request;
+
+class PlaygroundTestCase extends ApiTestCase
+{
+    public function testGuideRequest(): void
+    {
+        if (!\function_exists('App\Playground\request')) {
+            $this->markTestSkipped('No function request defined');
+
+            return;
+        }
+
+        $kernel = static::createKernel();
+        $request = request();
+        $response = $kernel->handle($request);
+        $kernel->terminate($request, $response);
+        $this->assertLessThan(500, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
Adds an "hidden" test suite that plays the request created for the Playground (in `App\Playground\request` ) if it is defined

closes #19 